### PR TITLE
optional use of env vars for use on servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ To configure your username and password run:
 bocker config set
 ```
 
+If you want to run bocker on server where there's no keyring tool installed, set the following environment variables:
+
+```sh
+export DOCKER_USERNAME=<your docker username>
+export DOCKER_PASSWORD=<your docker password>
+```
+
+`bocker` will prefer environment variables over the keyring.
+
 ![bocker config](https://vhs.charm.sh/vhs-6w65TVtSWeJqk5oGv5N9cp.gif)
 
 ### List existing backups

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,10 @@ func SetKey(service, secret string) error {
 
 // GetKey retrieves a key from the OS keyring
 func GetKey(service string) (string, error) {
+	if os.Getenv("DOCKER_PASSWORD") != "" {
+		return os.Getenv("DOCKER_PASSWORD"), nil
+	}
+	
 	// get password
 	secret, err := keyring.Get(service, AppName)
 	if err != nil {
@@ -109,6 +113,10 @@ func GetKey(service string) (string, error) {
 // GetUsername from configuration stored on the disk
 func GetUsername() (*Username, error) {
 	var username Username
+
+	if os.Getenv("DOCKER_USERNAME") != "" {
+		return &Username{Username: os.Getenv("DOCKER_USERNAME")}, nil
+	}
 
 	dir, err := xdg.ConfigFile(AppName)
 	if err != nil {


### PR DESCRIPTION
when using bocker on servers there's usually no keyring installed. in that case we can set the docker username and password via environment variables.
if the environment variables are set, bocker will ignore the configured values.