### PR TITLE
check validity of token

### DIFF
--- a/pkg/backup/list.go
+++ b/pkg/backup/list.go
@@ -64,7 +64,6 @@ type ListTagsResponse struct {
 func List(app config.Application) error {
 	c, err := docker.NewHTTPClient(app)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"bocker.software-services.dev/pkg/config"
@@ -22,6 +23,9 @@ type AuthResp struct {
 }
 
 func NewHTTPClient(app config.Application) (*HTTPClient, error) {
+	if strings.HasPrefix(app.Config.Docker.Password, "dckr_oat") {
+		return nil, fmt.Errorf("cannot use a docker organization token to list repositories")
+	}
 
 	c := http.Client{Timeout: 3 * time.Second}
 	path := "/v2/users/login"


### PR DESCRIPTION
docker oats cannot be used to browse repositories.
see https://github.com/docker/hub-feedback/issues/2445#issuecomment-2661004397