### PR TITLE
Fix critical security issues from review

### DIFF
--- a/cmd/configList.go
+++ b/cmd/configList.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var showPassword bool
+
 var configListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Registry Configuration",
@@ -38,16 +40,22 @@ var configListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		fmt.Printf("Username: %s\n", cfg.Username)
+
+		if !showPassword {
+			fmt.Println("Password: (hidden; pass --show-password to reveal)")
+			return
+		}
+
 		password, err := config.GetKey(config.AppName)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		fmt.Printf("Username: %s\nPassword: %s\n", cfg.Username, password)
-
+		fmt.Printf("Password: %s\n", password)
 	},
 }
 
 func init() {
 	configCmd.AddCommand(configListCmd)
+	configListCmd.Flags().BoolVar(&showPassword, "show-password", false, "Print the stored Docker Hub password to stdout")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,12 +155,12 @@ func SetUsername(username string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(fullPath, os.ModePerm)
+	err = os.MkdirAll(fullPath, 0700)
 	if err != nil {
 		return err
 	}
 
-	f, err := os.OpenFile(filepath.Join(fullPath, cfgFile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(filepath.Join(fullPath, cfgFile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -2,195 +2,190 @@ package db
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"bocker.software-services.dev/pkg/config"
 	"bocker.software-services.dev/pkg/logger"
 )
 
-func Dump(app config.Application) error {
-	var err error
+// identRE matches unquoted PostgreSQL identifiers: leading letter/underscore,
+// then letters, digits, or underscores, up to 63 bytes (PG's NAMEDATALEN - 1).
+var identRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,62}$`)
+
+// validateIdent rejects anything that isn't a plain PostgreSQL identifier.
+// We stay within the safe subset rather than supporting double-quoted names
+// so operator mistakes (--db-target 'foo;drop...') can't reach psql.
+func validateIdent(field, v string) error {
+	if !identRE.MatchString(v) {
+		return fmt.Errorf("invalid %s %q: must match %s", field, v, identRE.String())
+	}
+	return nil
+}
+
+// buildCmd resolves the binary and prepends `docker exec -- <container>` when
+// a container ID is configured. When PGPASSWORD is set in the caller's env,
+// it is forwarded into the container via `docker exec -e PGPASSWORD` (value
+// not on argv); on the host path, children inherit the env automatically.
+func buildCmd(containerID, tool string, args []string) (*exec.Cmd, error) {
+	if containerID == "" {
+		bin, err := exec.LookPath(tool)
+		if err != nil {
+			return nil, fmt.Errorf("%s not found: %w", tool, err)
+		}
+		bin, _ = filepath.Abs(bin)
+		return exec.Command(bin, args...), nil
+	}
+
+	dockerBin, err := exec.LookPath("docker")
+	if err != nil {
+		return nil, fmt.Errorf("docker not found: %w", err)
+	}
+	dockerBin, _ = filepath.Abs(dockerBin)
+
+	dockerArgs := []string{"exec"}
+	if _, ok := os.LookupEnv("PGPASSWORD"); ok {
+		dockerArgs = append(dockerArgs, "-e", "PGPASSWORD")
+	}
+	dockerArgs = append(dockerArgs, "--", containerID, tool)
+	dockerArgs = append(dockerArgs, args...)
+	return exec.Command(dockerBin, dockerArgs...), nil
+}
+
+// runCmd captures stderr, runs cmd, and wraps any non-zero exit with the
+// underlying *exec.ExitError plus trimmed stderr.
+func runCmd(cmd *exec.Cmd, tool string) (string, error) {
 	var outb, errb bytes.Buffer
-	var pgDumpBin string
-	var backupFilePath string
-	var pgDumpArgs []string
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	logger.LogCommand(cmd.Path + " " + strings.Join(cmd.Args[1:], " "))
+	if err := cmd.Run(); err != nil {
+		stderr := strings.TrimSpace(errb.String())
+		if stderr == "" {
+			return outb.String(), fmt.Errorf("%s failed: %w", tool, err)
+		}
+		return outb.String(), fmt.Errorf("%s failed: %w: %s", tool, err, stderr)
+	}
+	return outb.String(), nil
+}
+
+func Dump(app config.Application) error {
+	if err := validateIdent("db-source", app.Config.DB.SourceName); err != nil {
+		return err
+	}
+	if err := validateIdent("db-user", app.Config.DB.User); err != nil {
+		return err
+	}
 
 	app.Config.DB.BackupFileName = fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.DB.DateTime)
+	var backupFilePath string
 	if app.Config.Docker.ContainerID != "" {
 		backupFilePath = filepath.Join("/var/tmp", app.Config.DB.BackupFileName)
 	} else {
 		backupFilePath = filepath.Join(app.Config.TmpDir, app.Config.DB.BackupFileName)
 	}
 
-	pgDumpArgs = []string{"-F", "c", "-U", app.Config.DB.User, "-h", app.Config.DB.Host, app.Config.DB.SourceName, "-f", backupFilePath}
-
-	if app.Config.Docker.ContainerID != "" {
-		pgDumpBin, err = exec.LookPath("docker")
-		if err == nil {
-			pgDumpBin, _ = filepath.Abs(pgDumpBin)
-		} else {
-			return errors.New("docker not found")
-		}
-		pgDumpArgs = append([]string{"exec", app.Config.Docker.ContainerID, "pg_dump"}, pgDumpArgs...)
-	} else {
-		pgDumpBin, err = exec.LookPath("pg_dump")
-		if err == nil {
-			pgDumpBin, _ = filepath.Abs(pgDumpBin)
-		} else {
-			return err
-		}
-	}
-
-	logger.LogCommand(pgDumpBin + " " + strings.Join(pgDumpArgs, " "))
-	bkpCmd := exec.Command(pgDumpBin, pgDumpArgs...)
-	bkpCmd.Stdout = &outb
-	bkpCmd.Stderr = &errb
-	err = bkpCmd.Run()
+	args := []string{"-F", "c", "-U", app.Config.DB.User, "-h", app.Config.DB.Host, app.Config.DB.SourceName, "-f", backupFilePath}
+	cmd, err := buildCmd(app.Config.Docker.ContainerID, "pg_dump", args)
 	if err != nil {
-		return errors.New(errb.String())
+		return err
 	}
-	return nil
+	_, err = runCmd(cmd, "pg_dump")
+	return err
 }
 
 func ExportRoles(app config.Application) error {
-	var err error
-	var outb, errb bytes.Buffer
-	var rolesFilePath string
-	var pgDumpallBin string
-	var pgDumpallArgs []string
+	if err := validateIdent("db-user", app.Config.DB.User); err != nil {
+		return err
+	}
 
 	app.Config.DB.RolesFileName = fmt.Sprintf("%s_%s_roles_backup.sql", app.Config.DB.SourceName, app.Config.DB.DateTime)
 
+	var rolesFilePath string
 	if app.Config.Docker.ContainerID != "" {
 		rolesFilePath = filepath.Join("/var/tmp/", app.Config.DB.RolesFileName)
 	} else {
 		rolesFilePath = filepath.Join(app.Config.TmpDir, app.Config.DB.RolesFileName)
 	}
 
-	pgDumpallArgs = []string{"-U", app.Config.DB.User, "--clean", "--if-exists", "--no-comments", "--globals-only", fmt.Sprintf("--file=%s", rolesFilePath)}
-
-	if app.Config.Docker.ContainerID != "" {
-		pgDumpallBin, err = exec.LookPath("docker")
-		if err == nil {
-			pgDumpallBin, _ = filepath.Abs(pgDumpallBin)
-		} else {
-			return errors.New("docker not found")
-		}
-		pgDumpallArgs = append([]string{"exec", app.Config.Docker.ContainerID, "pg_dumpall"}, pgDumpallArgs...)
-	} else {
-		pgDumpallBin, err = exec.LookPath("pg_dumpall")
-		if err == nil {
-			pgDumpallBin, _ = filepath.Abs(pgDumpallBin)
-		} else {
-			return errors.New("pg_dumpall not found")
-		}
-	}
-
-	logger.LogCommand(pgDumpallBin + " " + strings.Join(pgDumpallArgs, " "))
-	bkpCmd := exec.Command(pgDumpallBin, pgDumpallArgs...)
-	bkpCmd.Stdout = &outb
-	bkpCmd.Stderr = &errb
-	err = bkpCmd.Run()
+	args := []string{"-U", app.Config.DB.User, "--clean", "--if-exists", "--no-comments", "--globals-only", fmt.Sprintf("--file=%s", rolesFilePath)}
+	cmd, err := buildCmd(app.Config.Docker.ContainerID, "pg_dumpall", args)
 	if err != nil {
-		return errors.New(errb.String())
+		return err
 	}
-	return nil
+	_, err = runCmd(cmd, "pg_dumpall")
+	return err
 }
 
 func CreateDB(app config.Application) error {
-	var err error
-	var outb, errb bytes.Buffer
-	var pgsqlBin string
-
-	stmt := fmt.Sprintf("CREATE DATABASE %s OWNER %s ENCODING UTF8", app.Config.DB.TargetName, app.Config.DB.Owner)
-	psqlArgs := []string{"-U", app.Config.DB.Owner, "-d", "postgres", "-c", stmt}
-
-	if app.Config.Docker.ContainerID != "" {
-		pgsqlBin, err = exec.LookPath("docker")
-		if err == nil {
-			pgsqlBin, _ = filepath.Abs(pgsqlBin)
-		} else {
-			return errors.New("docker not found")
-		}
-		psqlArgs = append([]string{"exec", app.Config.Docker.ContainerID, "psql"}, psqlArgs...)
-	} else {
-		pgsqlBin, err = exec.LookPath("psql")
-		if err == nil {
-			pgsqlBin, _ = filepath.Abs(pgsqlBin)
-		} else {
-			return errors.New("psql not found")
-		}
+	if err := validateIdent("db-target", app.Config.DB.TargetName); err != nil {
+		return err
+	}
+	if err := validateIdent("db-owner", app.Config.DB.Owner); err != nil {
+		return err
 	}
 
-	logger.LogCommand(pgsqlBin + " " + strings.Join(psqlArgs, " "))
-	psqlCmd := exec.Command(pgsqlBin, psqlArgs...)
-	psqlCmd.Stdout = &outb
-	psqlCmd.Stderr = &errb
-	err = psqlCmd.Run()
+	// Identifiers are validated above, but we still double-quote to defeat any
+	// future validator regression and to match PG's own escaping conventions.
+	stmt := fmt.Sprintf(`CREATE DATABASE "%s" OWNER "%s" ENCODING UTF8`,
+		app.Config.DB.TargetName, app.Config.DB.Owner)
+	args := []string{"-U", app.Config.DB.Owner, "-d", "postgres", "-c", stmt}
+
+	cmd, err := buildCmd(app.Config.Docker.ContainerID, "psql", args)
 	if err != nil {
-		if strings.Contains(errb.String(), "already exists") {
+		return err
+	}
+	if _, err := runCmd(cmd, "psql"); err != nil {
+		if strings.Contains(err.Error(), "already exists") {
 			logger.LogCommand("Database already exists, skipping creation...")
-		} else {
-			return errors.New(errb.String())
+			return nil
 		}
+		return err
 	}
 	return nil
 }
 
 func Restore(app config.Application) error {
-	var err error
-	var outb, errb bytes.Buffer
-	var pgRestoreBin string
-	var backupFile string
+	if err := validateIdent("db-source", app.Config.DB.SourceName); err != nil {
+		return err
+	}
+	if err := validateIdent("db-target", app.Config.DB.TargetName); err != nil {
+		return err
+	}
+	if err := validateIdent("db-owner", app.Config.DB.Owner); err != nil {
+		return err
+	}
 
 	app.Config.DB.BackupFileName = fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.Docker.Tag)
-
+	var backupFile string
 	if app.Config.Docker.ContainerID != "" {
 		backupFile = filepath.Join("/var/tmp", app.Config.DB.BackupFileName)
 	} else {
 		backupFile = filepath.Join(app.Config.TmpDir, app.Config.DB.BackupFileName)
 	}
 
-	pgRestoreArgs := []string{
+	args := []string{
 		"-U", app.Config.DB.Owner, "-F", "c", "-c", "-v",
 		fmt.Sprintf("--dbname=%s", app.Config.DB.TargetName),
 		"-h", app.Config.DB.Host,
 		backupFile,
 	}
 
-	if app.Config.Docker.ContainerID != "" {
-		pgRestoreBin, err = exec.LookPath("docker")
-		if err == nil {
-			pgRestoreBin, _ = filepath.Abs(pgRestoreBin)
-		} else {
-			return errors.New("docker not found")
-		}
-		pgRestoreArgs = append([]string{"exec", app.Config.Docker.ContainerID, "pg_restore"}, pgRestoreArgs...)
-	} else {
-		pgRestoreBin, err = exec.LookPath("pg_restore")
-		if err == nil {
-			pgRestoreBin, _ = filepath.Abs(pgRestoreBin)
-		} else {
-			return errors.New("pg_restore not found")
-		}
-	}
-
-	logger.LogCommand(pgRestoreBin + " " + strings.Join(pgRestoreArgs, " "))
-	pgRestoreCmd := exec.Command(pgRestoreBin, pgRestoreArgs...)
-	pgRestoreCmd.Stdout = &outb
-	pgRestoreCmd.Stderr = &errb
-	err = pgRestoreCmd.Run()
+	cmd, err := buildCmd(app.Config.Docker.ContainerID, "pg_restore", args)
 	if err != nil {
-		if strings.Contains(errb.String(), "errors ignored on restore") {
+		return err
+	}
+	if _, err := runCmd(cmd, "pg_restore"); err != nil {
+		if strings.Contains(err.Error(), "errors ignored on restore") {
 			logger.LogCommand("Some errors during restore where ignored.")
-			logger.LogCommand(errb.String())
-		} else {
-			return errors.New(errb.String())
+			logger.LogCommand(err.Error())
+			return nil
 		}
+		return err
 	}
 	return nil
 }

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -27,7 +27,7 @@ func NewHTTPClient(app config.Application) (*HTTPClient, error) {
 		return nil, fmt.Errorf("cannot use a docker organization token to list repositories")
 	}
 
-	c := http.Client{Timeout: 3 * time.Second}
+	c := http.Client{Timeout: 30 * time.Second}
 	path := "/v2/users/login"
 	body := struct {
 		Username string `json:"username"`
@@ -50,23 +50,22 @@ func NewHTTPClient(app config.Application) (*HTTPClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
-		if res.StatusCode == 401 {
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusUnauthorized {
 			return nil, fmt.Errorf("authentication failed, status code: %d", res.StatusCode)
-		} else {
-			return nil, fmt.Errorf("docker API error, status code: %d", res.StatusCode)
 		}
+		return nil, fmt.Errorf("docker API error, status code: %d", res.StatusCode)
 	}
-	decoder := json.NewDecoder(res.Body)
+
 	resp := &AuthResp{}
-	err = decoder.Decode(resp)
-	if err != nil {
+	if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 		return nil, err
 	}
 
 	return &HTTPClient{
-		httpClient: http.Client{Timeout: 3 * time.Second},
+		httpClient: c,
 		token:      resp.Token,
 		apiHost:    app.Config.Docker.Host,
 	}, nil

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -4,18 +4,28 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"bocker.software-services.dev/pkg/config"
 	"bocker.software-services.dev/pkg/logger"
 	"bocker.software-services.dev/pkg/tar"
 	"github.com/docker/docker/api/types/image"
 )
+
+// wrapExecErr produces an error that carries the underlying *exec.ExitError
+// (so callers can inspect the exit code) plus trimmed stderr for context.
+func wrapExecErr(tool string, err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return fmt.Errorf("%s failed: %w", tool, err)
+	}
+	return fmt.Errorf("%s failed: %w: %s", tool, err, stderr)
+}
 
 //go:embed "Dockerfile"
 var Dockerfile []byte
@@ -26,85 +36,83 @@ type DockerImage struct {
 	Layers   []string `json:"Layers"`
 }
 
+// dockerBin resolves an absolute path to the docker binary.
+func dockerBin() (string, error) {
+	bin, err := exec.LookPath("docker")
+	if err != nil {
+		return "", fmt.Errorf("docker not found: %w", err)
+	}
+	bin, _ = filepath.Abs(bin)
+	return bin, nil
+}
+
 // Copies a file from a running docker container to the app.Config.TmpDir
 func CopyFrom(app config.Application) error {
-	var outb, errb bytes.Buffer
 	app.Config.DB.BackupFileName = fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.DB.DateTime)
 
-	dockerBin, err := exec.LookPath("docker")
-	if err == nil {
-		dockerBin, _ = filepath.Abs(dockerBin)
+	bin, err := dockerBin()
+	if err != nil {
+		return err
 	}
 
-	// docker cp ${DB_CONTAINER}:/${BACKUP_FILE_NAME} ${BACKUP_DIR}/
-	cpArgs := []string{"cp", app.Config.Docker.ContainerID + ":/var/tmp/" + app.Config.DB.BackupFileName, app.Config.TmpDir}
-	cpCmd := exec.Command(dockerBin, cpArgs...)
+	// docker cp -- <container>:/var/tmp/<file> <dest>
+	cpArgs := []string{"cp", "--", app.Config.Docker.ContainerID + ":/var/tmp/" + app.Config.DB.BackupFileName, app.Config.TmpDir}
+	var outb, errb bytes.Buffer
+	cpCmd := exec.Command(bin, cpArgs...)
 	cpCmd.Stdout = &outb
 	cpCmd.Stderr = &errb
-	err = cpCmd.Run()
-	if err != nil {
-		return errors.New(errb.String())
+	if err := cpCmd.Run(); err != nil {
+		return wrapExecErr("docker cp", err, errb.String())
 	}
 	return nil
 }
 
 // Copies a file to a running docker container to /var/tmp
 func CopyTo(container, filename string) error {
-	var outb, errb bytes.Buffer
-
-	dockerBin, err := exec.LookPath("docker")
-	if err == nil {
-		dockerBin, _ = filepath.Abs(dockerBin)
+	bin, err := dockerBin()
+	if err != nil {
+		return err
 	}
 
-	// docker cp <filename> <container id>:/var/tmp/<filename>
-	cpArgs := []string{"cp", filename, container + ":/var/tmp/"}
-	cpCmd := exec.Command(dockerBin, cpArgs...)
+	// docker cp -- <filename> <container>:/var/tmp/
+	cpArgs := []string{"cp", "--", filename, container + ":/var/tmp/"}
+	var outb, errb bytes.Buffer
+	cpCmd := exec.Command(bin, cpArgs...)
 	cpCmd.Stdout = &outb
 	cpCmd.Stderr = &errb
-	err = cpCmd.Run()
-	if err != nil {
-		return errors.New(errb.String())
+	if err := cpCmd.Run(); err != nil {
+		return wrapExecErr("docker cp", err, errb.String())
 	}
 	return nil
 }
 
 func Build(app config.Application) error {
-	var outb, errb bytes.Buffer
-
-	// write Dockerfile
 	dockerfilePath := filepath.Join(app.Config.TmpDir, "Dockerfile")
-	err := os.WriteFile(dockerfilePath, Dockerfile, 0755)
-	if err != nil {
-		return fmt.Errorf("unable to write file: %v", err)
+	if err := os.WriteFile(dockerfilePath, Dockerfile, 0600); err != nil {
+		return fmt.Errorf("unable to write Dockerfile: %w", err)
 	}
 
 	app.Config.DB.BackupFileName = fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.DB.DateTime)
-	dockerBin, err := exec.LookPath("docker")
-	if err == nil {
-		dockerBin, _ = filepath.Abs(dockerBin)
+
+	bin, err := dockerBin()
+	if err != nil {
+		return err
 	}
 
-	var buildArgs []string
+	buildArgs := []string{"build",
+		"--build-arg", fmt.Sprintf("backup_file=%s", app.Config.DB.BackupFileName),
+	}
 	if app.Config.DB.ExportRoles {
-		buildArgs = []string{"build",
-			"--build-arg", fmt.Sprintf("backup_file=%s", app.Config.DB.BackupFileName),
-			"--build-arg", fmt.Sprintf("roles_file=%s", app.Config.DB.RolesFileName),
-			"-t", app.Config.Docker.ImagePath,
-			"-f", dockerfilePath, app.Config.TmpDir}
-	} else {
-		buildArgs = []string{"build",
-			"--build-arg", fmt.Sprintf("backup_file=%s", app.Config.DB.BackupFileName),
-			"-t", app.Config.Docker.ImagePath,
-			"-f", dockerfilePath, app.Config.TmpDir}
+		buildArgs = append(buildArgs, "--build-arg", fmt.Sprintf("roles_file=%s", app.Config.DB.RolesFileName))
 	}
+	buildArgs = append(buildArgs, "-t", app.Config.Docker.ImagePath, "-f", dockerfilePath, app.Config.TmpDir)
 
-	buildCmd := exec.Command(dockerBin, buildArgs...)
+	var outb, errb bytes.Buffer
+	buildCmd := exec.Command(bin, buildArgs...)
 	buildCmd.Stdout = &outb
 	buildCmd.Stderr = &errb
-	err = buildCmd.Run()
-	if err != nil {
-		return errors.New(errb.String())
+	if err := buildCmd.Run(); err != nil {
+		return wrapExecErr("docker build", err, errb.String())
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Addresses the **Critical** findings from the Go security review: command-injection hardening, exec-error propagation, secret hygiene, and an HTTP response-body leak.

### C1 — `PGPASSWORD` inside `docker exec`
When `--container-id` is set, `pg_dump`/`pg_dumpall`/`psql`/`pg_restore` runs inside the container via `docker exec`, which does **not** inherit the host's env. We now pass `docker exec -e PGPASSWORD` when the caller's env has it set — docker looks up the value itself, so the secret never lands on argv. The host path already inherited `os.Environ()` so no change there.

### C2 — DB identifier validation and `--` separators
- New `validateIdent` guards `--db-source`, `--db-target`, `--db-owner`, `--db-user` with a strict PG identifier regex (`[A-Za-z_][A-Za-z0-9_]{0,62}`). A value like `foo;drop database bar` is rejected before it can reach `psql -c`.
- `CREATE DATABASE` also double-quotes the identifiers it interpolates, as belt-and-braces.
- Every `docker exec` / `docker cp` now has `--` before positional args, so a container ID starting with `-` can't be interpreted as a flag.

### C3 — real exec errors
All `errors.New(errb.String())` sites replaced with `fmt.Errorf("<tool> failed: %w: %s", err, trimmedStderr)`. The underlying `*exec.ExitError` is preserved (callers can inspect exit codes via `errors.As`) and empty stderr no longer produces an empty-string error.

### C4 — config / secret hygiene
- XDG config dir permissions: `0777` → `0700`.
- Config file permissions: `0644` → `0600`.
- Embedded `Dockerfile` written `0755` → `0600` (it's never executed).
- `bocker config list` hides the Docker Hub password by default. Pass `--show-password` to reveal it.

### C6 — HTTP response-body leak in `NewHTTPClient`
- `defer res.Body.Close()` on all paths (previously leaked on non-2xx and 2xx).
- Reuses the single `http.Client` instead of allocating a second one.
- Uses `http.StatusOK` / `http.StatusUnauthorized` constants.
- Timeout raised 3s → 30s so first-time auth on slow links doesn't spuriously fail.

## Out of scope
The pre-existing `go vet` warning `pkg/docker/api_client.go:31: literal copies lock value from *c` (H6 in the review) is unchanged — separate PR.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` shows only the pre-existing H6 warning
- [x] `bocker config list` hides password; `--show-password` reveals it
- [ ] End-to-end backup against a Postgres container with `PGPASSWORD` set in the shell
- [ ] End-to-end restore including `CREATE DATABASE` on a validated target name
- [ ] Verify a bogus `--db-target 'foo;drop...'` is rejected before `psql` is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)