### PR TITLE
Fix high-severity issues from review

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"bocker.software-services.dev/pkg/tui"
-	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
 )
 
@@ -31,8 +30,8 @@ import (
 var backupCmd = &cobra.Command{
 	Use:   "backup",
 	Short: "Backup a Postgresql Database",
-	Long: `This command creates a Postgresql database backup with pg_dump. 
-The resulting file is wrapped in a Docker image. 
+	Long: `This command creates a Postgresql database backup with pg_dump.
+The resulting file is wrapped in a Docker image.
 Finally, this Docker image is uploaded to a Docker registy.
 
 Requires:
@@ -41,26 +40,21 @@ Requires:
 
 Example:
 bocker -H <host> -n <db name> -u <db user> -o <output file name>`,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		err := tui.InitBackupTui(app)
-		if err != nil {
-			log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return tui.InitBackupTui(cmd.Context(), app)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(backupCmd)
 	backupCmd.Flags().StringVarP(&app.Config.DB.User, "db-user", "u", "", "Database user name (required)")
-	backupCmd.Flags().StringVarP(&app.Config.DB.Host, "db-host", "", "localhost", "Hostname of the database host")
+	backupCmd.Flags().StringVar(&app.Config.DB.Host, "db-host", "localhost", "Hostname of the database host")
 	backupCmd.Flags().StringVarP(&app.Config.DB.SourceName, "db-source", "s", "", "Source database name")
 	backupCmd.Flags().StringVarP(&app.Config.Docker.ContainerID, "container-id", "c", "", "ID of container running PostgreSQL")
 	backupCmd.Flags().BoolVar(&app.Config.DB.ExportRoles, "export-roles", false, "Include roles in backup")
 	backupCmd.Flags().BoolVarP(&app.Config.DaemonMode, "daemon", "d", false, "Run in daemon mode (no TTY required)")
 
-	backupCmd.MarkFlagRequired("db-name")
-	backupCmd.MarkFlagRequired("db-user")
-	backupCmd.MarkFlagRequired("db-source")
-	rootCmd.MarkPersistentFlagRequired("repository")
+	_ = backupCmd.MarkFlagRequired("db-user")
+	_ = backupCmd.MarkFlagRequired("db-source")
+	_ = rootCmd.MarkPersistentFlagRequired("repository")
 }

--- a/cmd/configList.go
+++ b/cmd/configList.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"bocker.software-services.dev/pkg/config"
 	"github.com/spf13/cobra"
@@ -34,24 +33,24 @@ var showPassword bool
 var configListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List Registry Configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.GetUsername()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
-
 		fmt.Printf("Username: %s\n", cfg.Username)
 
 		if !showPassword {
 			fmt.Println("Password: (hidden; pass --show-password to reveal)")
-			return
+			return nil
 		}
 
 		password, err := config.GetKey(config.AppName)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		fmt.Printf("Password: %s\n", password)
+		return nil
 	},
 }
 

--- a/cmd/configSet.go
+++ b/cmd/configSet.go
@@ -23,8 +23,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"bocker.software-services.dev/pkg/config"
 	"github.com/spf13/cobra"
@@ -33,24 +31,17 @@ import (
 var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set Registry Configuration",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if username == "" || password == "" {
-			err := config.ConfigTui()
-			if err != nil {
-				fmt.Printf("could not start bocker: %s\n", err)
-				os.Exit(1)
+			if err := config.ConfigTui(); err != nil {
+				return fmt.Errorf("could not start bocker: %w", err)
 			}
-		} else {
-			err := config.SetUsername(username)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			err = config.SetKey(config.AppName, password)
-			if err != nil {
-				log.Fatal(err)
-			}
+			return nil
 		}
+		if err := config.SetUsername(username); err != nil {
+			return err
+		}
+		return config.SetKey(config.AppName, password)
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"bocker.software-services.dev/pkg/backup"
-	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
 )
 
@@ -31,18 +30,15 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List available backups",
-	Run: func(cmd *cobra.Command, args []string) {
-		app := app.Setup()
-
-		err := backup.List(*app)
-		if err != nil {
-			log.Error(err)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := app.Setup(); err != nil {
+			return err
 		}
-
+		return backup.List(cmd.Context(), *app)
 	},
 }
 
 func init() {
 	backupCmd.AddCommand(listCmd)
-	rootCmd.MarkPersistentFlagRequired("repository")
+	_ = rootCmd.MarkPersistentFlagRequired("repository")
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"bocker.software-services.dev/pkg/tui"
-	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +30,8 @@ import (
 var restoreCmd = &cobra.Command{
 	Use:   "restore",
 	Short: "Restore a Postgresql database",
-	Run: func(cmd *cobra.Command, args []string) {
-		err := tui.InitRestoreTui(app)
-		if err != nil {
-			log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return tui.InitRestoreTui(cmd.Context(), app)
 	},
 }
 
@@ -50,9 +46,9 @@ func init() {
 	restoreCmd.Flags().StringVarP(&app.Config.Docker.ContainerID, "container-id", "c", "", "ID of container running PostgreSQL")
 	restoreCmd.Flags().BoolVar(&app.Config.DB.ImportRoles, "import-roles", false, "Create roles from backup")
 
-	restoreCmd.MarkFlagRequired("tag")
-	restoreCmd.MarkFlagRequired("db-owner")
-	restoreCmd.MarkFlagRequired("db-source")
-	restoreCmd.MarkFlagRequired("db-target")
-	rootCmd.MarkPersistentFlagRequired("repository")
+	_ = restoreCmd.MarkFlagRequired("tag")
+	_ = restoreCmd.MarkFlagRequired("db-owner")
+	_ = restoreCmd.MarkFlagRequired("db-source")
+	_ = restoreCmd.MarkFlagRequired("db-target")
+	_ = rootCmd.MarkPersistentFlagRequired("repository")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,10 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"bocker.software-services.dev/pkg/config"
 	"github.com/spf13/cobra"
@@ -34,19 +37,23 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "bocker",
 		Short: "Create Postgresql backups and store them in Docker images",
-		Long: `Bocker is a command line tool which creates a backup from a PostgreSQL database, 
-wraps it in a Docker image, and uploads it to Docker Hub. Of course, Bocker will also do the 
+		Long: `Bocker is a command line tool which creates a backup from a PostgreSQL database,
+wraps it in a Docker image, and uploads it to Docker Hub. Of course, Bocker will also do the
 reverse and restore your database from a backup in Docker Hub.`,
+		// Returned errors are already reported by Execute; skip cobra's usage
+		// banner so a failing pg_dump doesn't dump the full --help on the user.
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 )
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+// Execute wires Ctrl+C into a cancellable context and runs the root command.
+// It returns whatever error the selected subcommand produced so main can decide
+// the exit code.
+func Execute() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return rootCmd.ExecuteContext(ctx)
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,9 @@ require (
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/adrg/xdg v0.5.3
-	github.com/charmbracelet/log v1.0.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/mattn/go-isatty v0.0.21
 	github.com/muesli/termenv v0.16.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,10 +20,8 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
-	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
@@ -37,7 +33,6 @@ require (
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
@@ -68,6 +63,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,16 +22,10 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
-github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
-github.com/charmbracelet/log v1.0.0 h1:HVVVMmfOorfj3BA9i8X8UL69Hoz9lI0PYwXfJvOdRc4=
-github.com/charmbracelet/log v1.0.0/go.mod h1:uYgY3SmLpwJWxmlrPwXvzVYujxis1vAKRV/0VQB7yWA=
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 h1:Q9fO0y1Zo5KB/5Vu8JZoLGm1N3RzF9bNj3Ao3xoR+Ac=
 github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
-github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
-github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
@@ -65,8 +59,6 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
-github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/main.go
+++ b/main.go
@@ -21,8 +21,16 @@ THE SOFTWARE.
 */
 package main
 
-import "bocker.software-services.dev/cmd"
+import (
+	"fmt"
+	"os"
+
+	"bocker.software-services.dev/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
 }

--- a/pkg/backup/list.go
+++ b/pkg/backup/list.go
@@ -1,11 +1,11 @@
 package backup
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -14,7 +14,6 @@ import (
 	"bocker.software-services.dev/pkg/docker"
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
-	"github.com/charmbracelet/log"
 )
 
 type Layer struct {
@@ -61,57 +60,55 @@ type ListTagsResponse struct {
 	Results  []Response `json:"results"`
 }
 
-func List(app config.Application) error {
+func List(ctx context.Context, app config.Application) error {
 	c, err := docker.NewHTTPClient(app)
 	if err != nil {
 		return err
 	}
 
 	path := fmt.Sprintf("/v2/namespaces/%s/repositories/%s/tags", app.Config.Docker.Namespace, app.Config.Docker.Repository)
-	resp, err := c.DoRequest(http.MethodGet, path, nil)
+	resp, err := c.DoRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode == 200 {
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		var tags ListTagsResponse
-		err = json.Unmarshal(bodyBytes, &tags)
-		if err != nil {
-			return err
-		}
+	defer resp.Body.Close()
 
-		columns := []table.Column{
-			{Title: "ID", Width: 10},
-			{Title: "Tag", Width: 20},
-			{Title: "Last Updated", Width: 25},
-			{Title: "Size", Width: 10},
-		}
-
-		var rows []table.Row
-		for _, v := range tags.Results {
-			size := float64(v.FullSize) / (1 << 20)
-			sizeStr := fmt.Sprintf("%.2f MiB", size)
-
-			dateTime, err := time.Parse(time.RFC3339, v.LastUpdated)
-			if err != nil {
-				return fmt.Errorf("cannot parse timestamp: %v", err)
-			}
-
-			rows = append(rows, []string{strconv.Itoa(v.ID), v.Name, dateTime.Format("02 Jan 2006 15:04 MST"), sizeStr})
-		}
-
-		m := tui.NewModel(columns, rows)
-		if _, err := tea.NewProgram(m).Run(); err != nil {
-			fmt.Printf("could not start bocker: %s\n", err)
-			os.Exit(1)
-		}
-
-	} else {
-		log.Error(resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("docker hub returned status %d", resp.StatusCode)
 	}
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var tags ListTagsResponse
+	if err := json.Unmarshal(bodyBytes, &tags); err != nil {
+		return err
+	}
+
+	columns := []table.Column{
+		{Title: "ID", Width: 10},
+		{Title: "Tag", Width: 20},
+		{Title: "Last Updated", Width: 25},
+		{Title: "Size", Width: 10},
+	}
+
+	rows := make([]table.Row, 0, len(tags.Results))
+	for _, v := range tags.Results {
+		size := float64(v.FullSize) / (1 << 20)
+		sizeStr := fmt.Sprintf("%.2f MiB", size)
+
+		dateTime, err := time.Parse(time.RFC3339, v.LastUpdated)
+		if err != nil {
+			return fmt.Errorf("cannot parse timestamp: %w", err)
+		}
+
+		rows = append(rows, []string{strconv.Itoa(v.ID), v.Name, dateTime.Format("02 Jan 2006 15:04 MST"), sizeStr})
+	}
+
+	m := tui.NewModel(columns, rows)
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		return fmt.Errorf("could not start backup list tui: %w", err)
+	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -10,7 +10,6 @@ import (
 	tui "bocker.software-services.dev/pkg/config/tui/setup"
 	tea "charm.land/bubbletea/v2"
 	"github.com/adrg/xdg"
-	"github.com/charmbracelet/log"
 	"github.com/zalando/go-keyring"
 	"gopkg.in/yaml.v3"
 )
@@ -42,7 +41,6 @@ type config struct {
 		ImportRoles    bool
 	}
 	TmpDir     string
-	Context    context.Context
 	DaemonMode bool
 }
 
@@ -54,60 +52,52 @@ type Username struct {
 	Username string `yaml:"username,omitempty"`
 }
 
-func (app Application) Setup() *Application {
+// Setup populates runtime fields (credentials, Docker host, timestamp) on the
+// Application. It mutates the receiver; call on a *Application shared with the
+// rest of the program.
+func (app *Application) Setup() error {
 	cfg, err := GetUsername()
 	if err != nil {
-		log.Fatal("Can't read configuration. Try running `bocker config` to fix the issue.", "err", err)
+		return fmt.Errorf("read config: %w (try running `bocker config` to fix)", err)
 	}
-
 	if cfg.Username == "" {
-		log.Fatal("Username not set. Run `bocker config` first.")
+		return errors.New("username not set; run `bocker config` first")
 	}
 	app.Config.Docker.Username = cfg.Username
 
 	app.Config.Docker.Password, err = GetKey(AppName)
 	if err != nil {
-		os.Exit(1)
+		return fmt.Errorf("read keyring: %w", err)
 	}
 
-	host, ok := os.LookupEnv("DOCKER_HOST")
-	if !ok {
-		app.Config.Docker.Host = "https://hub.docker.com"
-	} else {
+	if host, ok := os.LookupEnv("DOCKER_HOST"); ok {
 		app.Config.Docker.Host = host
+	} else {
+		app.Config.Docker.Host = "https://hub.docker.com"
 	}
 
-	dt := time.Now()
-	app.Config.DB.DateTime = dt.Format("2006-01-02_15-04-05")
-	app.Config.Context = context.Background()
-
-	return &app
+	app.Config.DB.DateTime = time.Now().Format("2006-01-02_15-04-05")
+	return nil
 }
 
 // SetKey creates a new entry in the OS keyring
 func SetKey(service, secret string) error {
-	err := keyring.Set(service, AppName, secret)
-	if err != nil {
-		log.Error("failed to fetch secret", "err", err)
-		return err
+	if err := keyring.Set(service, AppName, secret); err != nil {
+		return fmt.Errorf("keyring set: %w", err)
 	}
-
 	return nil
 }
 
 // GetKey retrieves a key from the OS keyring
 func GetKey(service string) (string, error) {
-	if os.Getenv("DOCKER_PASSWORD") != "" {
-		return os.Getenv("DOCKER_PASSWORD"), nil
+	if pw := os.Getenv("DOCKER_PASSWORD"); pw != "" {
+		return pw, nil
 	}
 
-	// get password
 	secret, err := keyring.Get(service, AppName)
 	if err != nil {
-		log.Error("failed to fetch key", "err", err)
-		return "", err
+		return "", fmt.Errorf("keyring get: %w", err)
 	}
-
 	return secret, nil
 }
 

--- a/pkg/config/tui/setup/setup.go
+++ b/pkg/config/tui/setup/setup.go
@@ -38,6 +38,10 @@ func InitialModel() Model {
 		t.SetStyles(styles)
 		t.CharLimit = 255
 		t.Prompt = ""
+		// bubbles v2 truncates the placeholder to one rune when Width is 0
+		// (see textinput.placeholderView). The surrounding border is 80 wide,
+		// so match it.
+		t.SetWidth(78)
 
 		switch i {
 		case 0:

--- a/pkg/config/tui/setup/setup.go
+++ b/pkg/config/tui/setup/setup.go
@@ -38,9 +38,6 @@ func InitialModel() Model {
 		t.SetStyles(styles)
 		t.CharLimit = 255
 		t.Prompt = ""
-		// bubbles v2 truncates the placeholder to one rune when Width is 0
-		// (see textinput.placeholderView). The surrounding border is 80 wide,
-		// so match it.
 		t.SetWidth(78)
 
 		switch i {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,14 +32,15 @@ func validateIdent(field, v string) error {
 // a container ID is configured. When PGPASSWORD is set in the caller's env,
 // it is forwarded into the container via `docker exec -e PGPASSWORD` (value
 // not on argv); on the host path, children inherit the env automatically.
-func buildCmd(containerID, tool string, args []string) (*exec.Cmd, error) {
+// ctx is propagated to exec.CommandContext so Ctrl+C cancels child processes.
+func buildCmd(ctx context.Context, containerID, tool string, args []string) (*exec.Cmd, error) {
 	if containerID == "" {
 		bin, err := exec.LookPath(tool)
 		if err != nil {
 			return nil, fmt.Errorf("%s not found: %w", tool, err)
 		}
 		bin, _ = filepath.Abs(bin)
-		return exec.Command(bin, args...), nil
+		return exec.CommandContext(ctx, bin, args...), nil
 	}
 
 	dockerBin, err := exec.LookPath("docker")
@@ -53,7 +55,7 @@ func buildCmd(containerID, tool string, args []string) (*exec.Cmd, error) {
 	}
 	dockerArgs = append(dockerArgs, "--", containerID, tool)
 	dockerArgs = append(dockerArgs, args...)
-	return exec.Command(dockerBin, dockerArgs...), nil
+	return exec.CommandContext(ctx, dockerBin, dockerArgs...), nil
 }
 
 // runCmd captures stderr, runs cmd, and wraps any non-zero exit with the
@@ -73,7 +75,7 @@ func runCmd(cmd *exec.Cmd, tool string) (string, error) {
 	return outb.String(), nil
 }
 
-func Dump(app config.Application) error {
+func Dump(ctx context.Context, app config.Application) error {
 	if err := validateIdent("db-source", app.Config.DB.SourceName); err != nil {
 		return err
 	}
@@ -90,7 +92,7 @@ func Dump(app config.Application) error {
 	}
 
 	args := []string{"-F", "c", "-U", app.Config.DB.User, "-h", app.Config.DB.Host, app.Config.DB.SourceName, "-f", backupFilePath}
-	cmd, err := buildCmd(app.Config.Docker.ContainerID, "pg_dump", args)
+	cmd, err := buildCmd(ctx, app.Config.Docker.ContainerID, "pg_dump", args)
 	if err != nil {
 		return err
 	}
@@ -98,7 +100,7 @@ func Dump(app config.Application) error {
 	return err
 }
 
-func ExportRoles(app config.Application) error {
+func ExportRoles(ctx context.Context, app config.Application) error {
 	if err := validateIdent("db-user", app.Config.DB.User); err != nil {
 		return err
 	}
@@ -113,7 +115,7 @@ func ExportRoles(app config.Application) error {
 	}
 
 	args := []string{"-U", app.Config.DB.User, "--clean", "--if-exists", "--no-comments", "--globals-only", fmt.Sprintf("--file=%s", rolesFilePath)}
-	cmd, err := buildCmd(app.Config.Docker.ContainerID, "pg_dumpall", args)
+	cmd, err := buildCmd(ctx, app.Config.Docker.ContainerID, "pg_dumpall", args)
 	if err != nil {
 		return err
 	}
@@ -121,7 +123,7 @@ func ExportRoles(app config.Application) error {
 	return err
 }
 
-func CreateDB(app config.Application) error {
+func CreateDB(ctx context.Context, app config.Application) error {
 	if err := validateIdent("db-target", app.Config.DB.TargetName); err != nil {
 		return err
 	}
@@ -135,7 +137,7 @@ func CreateDB(app config.Application) error {
 		app.Config.DB.TargetName, app.Config.DB.Owner)
 	args := []string{"-U", app.Config.DB.Owner, "-d", "postgres", "-c", stmt}
 
-	cmd, err := buildCmd(app.Config.Docker.ContainerID, "psql", args)
+	cmd, err := buildCmd(ctx, app.Config.Docker.ContainerID, "psql", args)
 	if err != nil {
 		return err
 	}
@@ -149,7 +151,7 @@ func CreateDB(app config.Application) error {
 	return nil
 }
 
-func Restore(app config.Application) error {
+func Restore(ctx context.Context, app config.Application) error {
 	if err := validateIdent("db-source", app.Config.DB.SourceName); err != nil {
 		return err
 	}
@@ -175,7 +177,7 @@ func Restore(app config.Application) error {
 		backupFile,
 	}
 
-	cmd, err := buildCmd(app.Config.Docker.ContainerID, "pg_restore", args)
+	cmd, err := buildCmd(ctx, app.Config.Docker.ContainerID, "pg_restore", args)
 	if err != nil {
 		return err
 	}

--- a/pkg/docker/api_client.go
+++ b/pkg/docker/api_client.go
@@ -13,7 +13,7 @@ import (
 )
 
 type APIClient struct {
-	docker client.Client
+	docker *client.Client
 }
 
 type Status struct {
@@ -27,8 +27,7 @@ func NewClient() (*APIClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return &APIClient{docker: *c}, nil
+	return &APIClient{docker: c}, nil
 }
 
 // Authentication returns a base64 encoded string of the docker username and password

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -71,9 +72,10 @@ func NewHTTPClient(app config.Application) (*HTTPClient, error) {
 	}, nil
 }
 
-// DoRequest makes a request to the Docker Hub API, caller is responsible to close response body
-func (c *HTTPClient) DoRequest(method, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, c.apiHost+path, body)
+// DoRequest makes a request to the Docker Hub API; the caller is responsible
+// for closing the response body.
+func (c *HTTPClient) DoRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.apiHost+path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -47,7 +48,7 @@ func dockerBin() (string, error) {
 }
 
 // Copies a file from a running docker container to the app.Config.TmpDir
-func CopyFrom(app config.Application) error {
+func CopyFrom(ctx context.Context, app config.Application) error {
 	app.Config.DB.BackupFileName = fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.DB.DateTime)
 
 	bin, err := dockerBin()
@@ -58,7 +59,7 @@ func CopyFrom(app config.Application) error {
 	// docker cp -- <container>:/var/tmp/<file> <dest>
 	cpArgs := []string{"cp", "--", app.Config.Docker.ContainerID + ":/var/tmp/" + app.Config.DB.BackupFileName, app.Config.TmpDir}
 	var outb, errb bytes.Buffer
-	cpCmd := exec.Command(bin, cpArgs...)
+	cpCmd := exec.CommandContext(ctx, bin, cpArgs...)
 	cpCmd.Stdout = &outb
 	cpCmd.Stderr = &errb
 	if err := cpCmd.Run(); err != nil {
@@ -68,7 +69,7 @@ func CopyFrom(app config.Application) error {
 }
 
 // Copies a file to a running docker container to /var/tmp
-func CopyTo(container, filename string) error {
+func CopyTo(ctx context.Context, container, filename string) error {
 	bin, err := dockerBin()
 	if err != nil {
 		return err
@@ -77,7 +78,7 @@ func CopyTo(container, filename string) error {
 	// docker cp -- <filename> <container>:/var/tmp/
 	cpArgs := []string{"cp", "--", filename, container + ":/var/tmp/"}
 	var outb, errb bytes.Buffer
-	cpCmd := exec.Command(bin, cpArgs...)
+	cpCmd := exec.CommandContext(ctx, bin, cpArgs...)
 	cpCmd.Stdout = &outb
 	cpCmd.Stderr = &errb
 	if err := cpCmd.Run(); err != nil {
@@ -86,7 +87,7 @@ func CopyTo(container, filename string) error {
 	return nil
 }
 
-func Build(app config.Application) error {
+func Build(ctx context.Context, app config.Application) error {
 	dockerfilePath := filepath.Join(app.Config.TmpDir, "Dockerfile")
 	if err := os.WriteFile(dockerfilePath, Dockerfile, 0600); err != nil {
 		return fmt.Errorf("unable to write Dockerfile: %w", err)
@@ -108,7 +109,7 @@ func Build(app config.Application) error {
 	buildArgs = append(buildArgs, "-t", app.Config.Docker.ImagePath, "-f", dockerfilePath, app.Config.TmpDir)
 
 	var outb, errb bytes.Buffer
-	buildCmd := exec.Command(bin, buildArgs...)
+	buildCmd := exec.CommandContext(ctx, bin, buildArgs...)
 	buildCmd.Stdout = &outb
 	buildCmd.Stderr = &errb
 	if err := buildCmd.Run(); err != nil {
@@ -117,7 +118,7 @@ func Build(app config.Application) error {
 	return nil
 }
 
-func Push(app config.Application) error {
+func Push(ctx context.Context, app config.Application) error {
 	c, err := NewClient()
 	if err != nil {
 		return err
@@ -129,21 +130,16 @@ func Push(app config.Application) error {
 		return err
 	}
 
-	out, err := c.docker.ImagePush(app.Config.Context, app.Config.Docker.ImagePath, image.PushOptions{RegistryAuth: authStr})
+	out, err := c.docker.ImagePush(ctx, app.Config.Docker.ImagePath, image.PushOptions{RegistryAuth: authStr})
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	err = c.ParseOutput(out)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.ParseOutput(out)
 }
 
-func Pull(app config.Application) error {
+func Pull(ctx context.Context, app config.Application) error {
 	c, err := NewClient()
 	if err != nil {
 		return err
@@ -155,20 +151,16 @@ func Pull(app config.Application) error {
 		return err
 	}
 
-	out, err := c.docker.ImagePull(app.Config.Context, app.Config.Docker.ImagePath, image.PullOptions{RegistryAuth: authStr})
+	out, err := c.docker.ImagePull(ctx, app.Config.Docker.ImagePath, image.PullOptions{RegistryAuth: authStr})
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	err = c.ParseOutput(out)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.ParseOutput(out)
 }
 
-func Save(app config.Application, outputFile string) (string, error) {
+func Save(ctx context.Context, app config.Application, outputFile string) (string, error) {
 	outputFilePath := filepath.Join(app.Config.TmpDir, outputFile)
 
 	c, err := NewClient()
@@ -177,7 +169,7 @@ func Save(app config.Application, outputFile string) (string, error) {
 	}
 	defer c.docker.Close()
 
-	rc, err := c.docker.ImageSave(app.Config.Context, []string{app.Config.Docker.ImagePath})
+	rc, err := c.docker.ImageSave(ctx, []string{app.Config.Docker.ImagePath})
 	if err != nil {
 		return "", err
 	}
@@ -189,25 +181,22 @@ func Save(app config.Application, outputFile string) (string, error) {
 	}
 	defer f.Close()
 
-	_, err = io.Copy(f, rc)
-	if err != nil {
+	if _, err := io.Copy(f, rc); err != nil {
 		return "", err
 	}
-
 	return outputFilePath, nil
 }
 
-func Unpack(app config.Application) error {
+func Unpack(ctx context.Context, app config.Application) error {
 	outputFile := "output.tar"
-	outputFilePath, err := Save(app, outputFile)
+	outputFilePath, err := Save(ctx, app, outputFile)
 	if err != nil {
 		return err
 	}
 
 	// unpack layer
 	manifestFile := "manifest.json"
-	err = tar.Untar(outputFilePath, manifestFile, app.Config.TmpDir)
-	if err != nil {
+	if err := tar.Untar(ctx, outputFilePath, manifestFile, app.Config.TmpDir); err != nil {
 		logger.LogCommand("Couldn't unpack file")
 		logger.LogCommand(err.Error())
 		return err
@@ -219,22 +208,18 @@ func Unpack(app config.Application) error {
 		return err
 	}
 	var manifest []DockerImage
-	err = json.Unmarshal(file, &manifest)
-	if err != nil {
+	if err := json.Unmarshal(file, &manifest); err != nil {
 		return err
+	}
+	if len(manifest) == 0 || len(manifest[0].Layers) == 0 {
+		return fmt.Errorf("docker image manifest has no layers")
 	}
 
 	backupLayerTar := manifest[0].Layers[len(manifest[0].Layers)-1]
-
-	err = tar.Untar(filepath.Join(app.Config.TmpDir, outputFile), backupLayerTar, app.Config.TmpDir)
-	if err != nil {
+	if err := tar.Untar(ctx, filepath.Join(app.Config.TmpDir, outputFile), backupLayerTar, app.Config.TmpDir); err != nil {
 		return err
 	}
 
 	app.Config.DB.BackupFileName = fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.Docker.Tag)
-	err = tar.Untar(filepath.Join(app.Config.TmpDir, backupLayerTar), app.Config.DB.BackupFileName, app.Config.TmpDir)
-	if err != nil {
-		return err
-	}
-	return nil
+	return tar.Untar(ctx, filepath.Join(app.Config.TmpDir, backupLayerTar), app.Config.DB.BackupFileName, app.Config.TmpDir)
 }

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -1,25 +1,30 @@
 package tar
 
 import (
+	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/pkg/errors"
+	"strings"
 )
 
-// Untar extracts a single file from a tar file.
-func Untar(tarFile, extractFile, dir string) error {
+// Untar extracts a single file from a tar file into dir.
+func Untar(ctx context.Context, tarFile, extractFile, dir string) error {
 	tarBin, err := exec.LookPath("tar")
-	if err == nil {
-		tarBin, _ = filepath.Abs(tarBin)
-	} else {
-		return err
+	if err != nil {
+		return fmt.Errorf("tar not found: %w", err)
 	}
-	unpackArgs := []string{"-xf", tarFile, extractFile}
-	unpackCmd := exec.Command(tarBin, unpackArgs...)
+	tarBin, _ = filepath.Abs(tarBin)
+
+	unpackCmd := exec.CommandContext(ctx, tarBin, "-xf", tarFile, extractFile)
 	unpackCmd.Dir = dir
-	if output, err := unpackCmd.CombinedOutput(); err != nil {
-		return errors.Wrap(err, string(output))
+	output, err := unpackCmd.CombinedOutput()
+	if err != nil {
+		out := strings.TrimSpace(string(output))
+		if out == "" {
+			return fmt.Errorf("tar failed: %w", err)
+		}
+		return fmt.Errorf("tar failed: %w: %s", err, out)
 	}
 	return nil
 }

--- a/pkg/tui/backup.go
+++ b/pkg/tui/backup.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -12,8 +13,10 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-func InitBackupTui(app *config.Application) error {
-	app = app.Setup()
+func InitBackupTui(ctx context.Context, app *config.Application) error {
+	if err := app.Setup(); err != nil {
+		return err
+	}
 	app.Config.Docker.Tag = app.Config.DB.DateTime
 	app.Config.Docker.ImagePath = fmt.Sprintf("%s/%s:%s", app.Config.Docker.Namespace, app.Config.Docker.Repository, app.Config.Docker.Tag)
 
@@ -29,8 +32,7 @@ func InitBackupTui(app *config.Application) error {
 		{
 			Name: "Creating Backup",
 			Action: func() error {
-				err := db.Dump(*app)
-				if err != nil {
+				if err := db.Dump(ctx, *app); err != nil {
 					logger.LogCommand("pg_dump failed")
 					logger.LogCommand(err.Error())
 					return err
@@ -38,45 +40,41 @@ func InitBackupTui(app *config.Application) error {
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Exporting Roles",
 			Action: func() error {
-				if app.Config.DB.ExportRoles {
-					err := db.ExportRoles(*app)
-					if err != nil {
-						logger.LogCommand("failed to export roles")
-						logger.LogCommand(err.Error())
-						return err
-					}
+				if !app.Config.DB.ExportRoles {
+					return nil
+				}
+				if err := db.ExportRoles(ctx, *app); err != nil {
+					logger.LogCommand("failed to export roles")
+					logger.LogCommand(err.Error())
+					return err
 				}
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Copy from Container",
 			Action: func() error {
-				if app.Config.Docker.ContainerID != "" {
-					err := docker.CopyFrom(*app)
-					if err != nil {
-						logger.LogCommand("failed to copy backup from container")
-						logger.LogCommand(err.Error())
-						return err
-					}
+				if app.Config.Docker.ContainerID == "" {
+					return nil
+				}
+				if err := docker.CopyFrom(ctx, *app); err != nil {
+					logger.LogCommand("failed to copy backup from container")
+					logger.LogCommand(err.Error())
+					return err
 				}
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Building Image",
 			Action: func() error {
-				err := docker.Build(*app)
-				if err != nil {
+				if err := docker.Build(ctx, *app); err != nil {
 					logger.LogCommand("failed to building image")
 					logger.LogCommand(err.Error())
 					return err
@@ -84,13 +82,11 @@ func InitBackupTui(app *config.Application) error {
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Pushing Image",
 			Action: func() error {
-				err := docker.Push(*app)
-				if err != nil {
+				if err := docker.Push(ctx, *app); err != nil {
 					logger.LogCommand("failed to push image")
 					logger.LogCommand(err.Error())
 					return err
@@ -98,7 +94,6 @@ func InitBackupTui(app *config.Application) error {
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 	}
 

--- a/pkg/tui/restore.go
+++ b/pkg/tui/restore.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,17 +9,19 @@ import (
 	"bocker.software-services.dev/pkg/config"
 	"bocker.software-services.dev/pkg/db"
 	"bocker.software-services.dev/pkg/docker"
+	"bocker.software-services.dev/pkg/logger"
 	tea "charm.land/bubbletea/v2"
-	"github.com/charmbracelet/log"
 )
 
-func InitRestoreTui(app *config.Application) error {
-	app = app.Setup()
+func InitRestoreTui(ctx context.Context, app *config.Application) error {
+	if err := app.Setup(); err != nil {
+		return err
+	}
 	app.Config.Docker.ImagePath = fmt.Sprintf("%s/%s:%s", app.Config.Docker.Namespace, app.Config.Docker.Repository, app.Config.Docker.Tag)
 
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
-		log.Error(err)
+		return fmt.Errorf("create tmp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	app.Config.TmpDir = tmpDir
@@ -27,96 +30,88 @@ func InitRestoreTui(app *config.Application) error {
 		{
 			Name: "Pull Backup Image",
 			Action: func() error {
-				err := docker.Pull(*app)
-				if err != nil {
-					log.Error("docker pull failed", "err", err)
+				if err := docker.Pull(ctx, *app); err != nil {
+					logger.LogCommand("docker pull failed")
+					logger.LogCommand(err.Error())
 					return err
 				}
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Extracting backup from image",
 			Action: func() error {
-				err := docker.Unpack(*app)
-				if err != nil {
-					log.Error("failed to extract backup", "err", err)
+				if err := docker.Unpack(ctx, *app); err != nil {
+					logger.LogCommand("failed to extract backup")
+					logger.LogCommand(err.Error())
 					return err
 				}
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Creating Database",
 			Action: func() error {
-				err := db.CreateDB(*app)
-				if err != nil {
-					log.Error("failed to create database", "err", err)
+				if err := db.CreateDB(ctx, *app); err != nil {
+					logger.LogCommand("failed to create database")
+					logger.LogCommand(err.Error())
 					return err
 				}
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
 		},
 		{
 			Name: "Copy backup to container",
 			Action: func() error {
+				if app.Config.Docker.ContainerID == "" {
+					return nil
+				}
 				backupFile := filepath.Join(app.Config.TmpDir, fmt.Sprintf("%s_%s_backup.psql", app.Config.DB.SourceName, app.Config.Docker.Tag))
-				if app.Config.Docker.ContainerID != "" {
-					err = docker.CopyTo(app.Config.Docker.ContainerID, backupFile)
-					if err != nil {
-						log.Error("failed to copy backup to container", "err", err)
-						return err
-					}
-				}
-				return nil
-			},
-			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
-		},
-		{
-			Name: "Import Roles",
-			Action: func() error {
-				if app.Config.DB.ImportRoles {
-					rolesFile := filepath.Join(app.Config.TmpDir, fmt.Sprintf("%s_%s_roles_backup.sql", app.Config.DB.SourceName, app.Config.DB.DateTime))
-					if app.Config.Docker.ContainerID != "" {
-						err = docker.CopyTo(app.Config.Docker.ContainerID, rolesFile)
-						if err != nil {
-							log.Error("failed to import roles", "err", err)
-							return err
-						}
-					}
-				}
-				return nil
-			},
-			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
-		},
-		{
-			Name: "Restoring Database",
-			Action: func() error {
-				err := db.Restore(*app)
-				if err != nil {
-					log.Error("failed to restore database", "err", err)
+				if err := docker.CopyTo(ctx, app.Config.Docker.ContainerID, backupFile); err != nil {
+					logger.LogCommand("failed to copy backup to container")
+					logger.LogCommand(err.Error())
 					return err
 				}
 				return nil
 			},
 			IsCompleteFunc: func() bool { return false },
-			IsComplete:     false,
+		},
+		{
+			Name: "Import Roles",
+			Action: func() error {
+				if !app.Config.DB.ImportRoles || app.Config.Docker.ContainerID == "" {
+					return nil
+				}
+				rolesFile := filepath.Join(app.Config.TmpDir, fmt.Sprintf("%s_%s_roles_backup.sql", app.Config.DB.SourceName, app.Config.DB.DateTime))
+				if err := docker.CopyTo(ctx, app.Config.Docker.ContainerID, rolesFile); err != nil {
+					logger.LogCommand("failed to import roles")
+					logger.LogCommand(err.Error())
+					return err
+				}
+				return nil
+			},
+			IsCompleteFunc: func() bool { return false },
+		},
+		{
+			Name: "Restoring Database",
+			Action: func() error {
+				if err := db.Restore(ctx, *app); err != nil {
+					logger.LogCommand("failed to restore database")
+					logger.LogCommand(err.Error())
+					return err
+				}
+				return nil
+			},
+			IsCompleteFunc: func() bool { return false },
 		},
 	}
 
 	m := newModel(stages)
-	_, err = tea.NewProgram(&m).Run()
-	if err != nil {
-		return err
+	if _, err := tea.NewProgram(&m).Run(); err != nil {
+		return fmt.Errorf("failed to run restore tui: %w", err)
 	}
-
 	return nil
 }

--- a/pkg/tui/stages.go
+++ b/pkg/tui/stages.go
@@ -32,15 +32,23 @@ func startDeployCmd() tea.Msg {
 	return startDeployMsg{}
 }
 
-func (m *model) runStage() tea.Msg {
-	if !m.stages[m.stageIndex].IsCompleteFunc() {
-		// Run the current stage, and record its result status
-		m.stages[m.stageIndex].Error = m.stages[m.stageIndex].Action()
+// runStageCmd runs the given stage's Action on bubbletea's Cmd goroutine and
+// ferries the result back as a stageCompleteMsg. It does not touch model state
+// directly — that's Update's job — which is what lets View read the model
+// concurrently without a data race.
+func runStageCmd(stage Stage, idx int) tea.Cmd {
+	return func() tea.Msg {
+		if stage.IsCompleteFunc() {
+			return stageCompleteMsg{idx: idx}
+		}
+		return stageCompleteMsg{idx: idx, err: stage.Action()}
 	}
-	return stageCompleteMsg{}
 }
 
-type stageCompleteMsg struct{}
+type stageCompleteMsg struct {
+	idx int
+	err error
+}
 
 type errMsg struct{ err error }
 
@@ -55,23 +63,20 @@ func (m *model) Init() tea.Cmd {
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case stageCompleteMsg:
-		// If we have an error, then set the error so that the views can properly update
-		if m.stages[m.stageIndex].Error != nil {
-			m.Error = m.stages[m.stageIndex].Error
+		m.stages[msg.idx].Error = msg.err
+		if msg.err != nil {
+			m.Error = msg.err
 			logger.WriteCommandLogFile(m.Error)
 			return m, tea.Quit
 		}
-		// Otherwise, mark the current stage as complete and move to the next stage
-		m.stages[m.stageIndex].IsComplete = true
-		m.stages[m.stageIndex].IsActive = false
-		// If we've reached the end of the defined stages, we're done
+		m.stages[msg.idx].IsComplete = true
+		m.stages[msg.idx].IsActive = false
 		if m.stageIndex+1 >= len(m.stages) {
 			return m, tea.Quit
 		}
 		m.stageIndex++
-		// set next stage to active
 		m.stages[m.stageIndex].IsActive = true
-		return m, m.runStage
+		return m, runStageCmd(m.stages[m.stageIndex], m.stageIndex)
 
 	case errMsg:
 		m.Error = msg
@@ -84,7 +89,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case startDeployMsg:
 		m.stages[m.stageIndex].IsActive = true
-		return m, m.runStage
+		return m, runStageCmd(m.stages[m.stageIndex], m.stageIndex)
 	}
 
 	var spinnerCmd tea.Cmd


### PR DESCRIPTION
## Summary
Addresses the **High** findings from the Go review — mostly design and error-handling hygiene, plus a real race in the TUI.

### H1 + H7 — `Setup` pointer receiver and context propagation
`Application.Setup` was a value-receiver method that mutated a copy and returned `&copy`; the original caller's struct was left half-populated. It's now `(*Application).Setup() error`, mutating in place. `log.Fatal`/`os.Exit` inside `Setup` are gone — all failure modes return an error.

The `Context context.Context` field on `config.config` was removed (it's an [anti-pattern](https://go.dev/blog/context-and-structs) to stash a Context on a struct). A `ctx` is now threaded explicitly through `db.*`, `docker.*`, `tar.Untar`, `backup.List`, `InitBackupTui`, `InitRestoreTui`. `Execute()` installs `signal.NotifyContext(…, SIGINT, SIGTERM)` and hands the ctx to cobra via `ExecuteContext`; subcommands pick it up via `cmd.Context()`. Practical effect: Ctrl+C now cancels a Docker push, a long `pg_dump`, or an `ImagePull` mid-stream instead of waiting them out.

### H3 — `Run` → `RunE`, no more `log.Fatal` in `pkg/`
Every cobra `Run` became `RunE` returning an error. `main.go` prints to stderr and exits non-zero. `rootCmd` sets `SilenceUsage`/`SilenceErrors` so a failing `pg_dump` doesn't spam `--help`. All `log.Fatal`/`os.Exit` calls in `pkg/` are removed — library code doesn't get to kill the process anymore.

### H4 — drop `github.com/pkg/errors`
Replaced with `fmt.Errorf(\"…: %w\", err)` in `pkg/tar/tar.go`; module dependency removed.

### H6 — `APIClient` stores the pointer
`APIClient{docker: *c}` dereferenced the Docker client struct by value. The Docker client now contains a `sync/atomic.Bool` with a `noCopy` marker; `go vet` was flagging `literal copies lock value`. Store `*client.Client` instead.

### H8 — stage execution race
`(m *model).runStage` wrote `m.stages[i].Error` from bubbletea's `Cmd` goroutine while `View` was reading it on the main loop. The new `runStageCmd(stage, idx)` closes over the stage and returns a `stageCompleteMsg{idx, err}`; all model mutation happens inside `Update`. No more concurrent state writes.

### H9 — dead `MarkFlagRequired(\"db-name\")`
`backupCmd.MarkFlagRequired(\"db-name\")` referenced a flag that was never declared (actual flag is `--db-source`). `MarkFlagRequired` returns an error on an unknown flag name, which was discarded — the line was silently dead. Removed, and every remaining `MarkFlagRequired` has its error explicitly ignored with `_ =` so the pattern is visible.

## Drive-by
- `docker.Unpack` guards against an empty manifest / empty layers slice (previously panicked on a corrupt tar).
- `backup.List` closes `resp.Body`, uses `http.StatusOK`, and surfaces non-200s as errors instead of logging-and-returning-nil.

## Deliberately out of scope
- **H2** (shared `app` global + `--db-host` declared twice) needs a per-command opts refactor — both sites currently default to `\"localhost\"` so the \"last init wins\" ordering is benign in practice. Follow-up PR.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (H6 warning is gone)
- [x] `go build -race -o /tmp/bocker_hi .` succeeds
- [x] Missing required flag -> error message + non-zero exit
- [x] `bocker config list` still hides password; `--show-password` reveals
- [ ] End-to-end `bocker backup` TUI with Ctrl+C cancels mid-push
- [ ] `bocker backup list` prints tags
- [ ] `bocker restore` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)